### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "refactoringui/heroicons",
+  "license": "MIT",
+  "require": {
+  }
+}


### PR DESCRIPTION
Add Composer support so you can put Heroicons on Packagist, to allow PHP projects to import them without the use of other package managers.