### PR TITLE
Update `arrows-expand.svg` solid style color

### DIFF
--- a/src/solid/arrows-expand.svg
+++ b/src/solid/arrows-expand.svg
@@ -1,3 +1,3 @@
 <svg width="19" height="20" viewBox="0 0 19 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 8V4M3 4H7M3 4L7 8M15 8V4M15 4H11M15 4L11 8M3 12V16M3 16H7M3 16L7 12M15 16L11 12M15 16V12M15 16H11" stroke="#374151" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 8V4M3 4H7M3 4L7 8M15 8V4M15 4H11M15 4L11 8M3 12V16M3 16H7M3 16L7 12M15 16L11 12M15 16V12M15 16H11" stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
Since the `arrows-expand` icon path uses `stroke` instead of `fill`, the current color doesn't look like the used one in the main site.

This shouldn't be the final solution because this icon should be flat and not use strokes, as it belongs to `solid` styles.