### PR TITLE
Make it possible to create React icons

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{ 
+"semi": true,
+"tabWidth": 2,
+"singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -36,3 +36,23 @@ To use these icons, simply copy the source for the icon you need from [heroicons
 Both icon styles are preconfigured to be stylable by setting the `color` CSS property, either manually or using utility classes like `text-gray-500` in a framework like [Tailwind CSS](https://tailwindcss.com).
 
 We also publish the icons to npm as `heroicons`, but we don't consider the directory structure stable yet and it could change in any release, so use the npm package at your own risk right now.
+
+## Use our icons as React's components
+
+First, install the dependencies. ```npm install```.
+
+To create the React's components. Run:
+```bash
+node ./scripts/build-react-icons.js
+```
+That would create two folders in `./react-icons/`. The folder `outline` for the outline icons, and `solid` folder for the solid ones. Inside you may find `*.js` files.
+
+If you use `Typescript`. You can get them by running:
+```bash
+node ./scripts/build-react-icons.js tsx=true
+```
+
+You can delete those `*.js` or `*.tsx` files by running:
+```bash
+node ./scripts/delete-react-icons.js
+```

--- a/package.json
+++ b/package.json
@@ -27,5 +27,12 @@
     "vue/",
     "outline/",
     "solid/"
-  ]
+  ],
+  "dependencies": {
+    "@svgr/plugin-jsx": "^5.5.0",
+    "@svgr/plugin-prettier": "^5.5.0",
+    "@svgr/plugin-svgo": "^5.5.0",
+    "capitalize": "^2.0.3",
+    "fs-extra": "^9.1.0"
+  }
 }

--- a/scripts/build-react-icons.js
+++ b/scripts/build-react-icons.js
@@ -1,0 +1,98 @@
+const fs = require('fs').promises;
+const fse = require('fs-extra');
+const svgr = require('@svgr/core').default;
+const capitalize = require('capitalize');
+
+const getIconsNames = async ({
+  areSolid,
+}) => await fs.readdir(`./src/${areSolid ? 'solid' : 'outline'}/`);
+
+const renameIconName = async ({
+  iconName,
+  isSolid,
+}) => await fs.rename(`./src/${isSolid ? 'solid' : 'outline'}/${iconName}`, `./src/${isSolid ? 'solid' : 'outline'}/${iconName.replace('svg', 'txt')}`);
+
+const undoRenameIconName = async ({
+  iconName,
+  isSolid,
+}) => await fs.rename(`./src/${isSolid ? 'solid' : 'outline'}/${iconName}`, `./src/${isSolid ? 'solid' : 'outline'}/${iconName.replace('txt', 'svg')}`);
+
+const getTextFromIcon = async ({
+  iconName,
+  isSolid,
+}) => await fs.readFile(`./src/${isSolid ? 'solid' : 'outline'}/${iconName}`, 'utf-8');
+
+const transformIconToReactIcon = async ({
+  iconCode,
+  componentName,
+}) => await svgr(iconCode, {
+  plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx', '@svgr/plugin-prettier'],
+  icon: true,
+}, { componentName });
+
+const createReactIcon = async ({
+  componentName,
+  isSolid,
+  reactIcon,
+  tsx,
+}) => await fse.outputFile(`./react-icons/${isSolid ? 'solid' : 'outline'}/${componentName}.${tsx ? 'tsx' : 'js'}`, reactIcon, 'utf-8');
+
+async function buildReactIcons({
+  isSolid,
+  tsx = process.argv[2],
+}) {
+  const iconsNames = await getIconsNames({
+    areSolid: false,
+  });
+
+  iconsNames.forEach(async (iconName) => {
+    // There's a weird file which isn't svg.
+    if (iconName === '.DS_Store') return;
+
+    if (iconName.endsWith('.svg')) {
+      await renameIconName({
+        iconName,
+        isSolid,
+      });
+    }
+
+    // Now it ends in '*.txt'.
+    iconName = iconName.replace('svg', 'txt');
+    // The text is actually the code.
+    const iconCode = await getTextFromIcon({
+      iconName,
+      isSolid,
+    });
+
+    // The componentName is actually the reactIcon's name.
+    const componentName = capitalize.words(iconName.replace('.txt', '').replace(/-/g, ' ')).replace(/ /g, '');
+    // The reactIcon is the component's code.
+    const reactIcon = await transformIconToReactIcon({
+      iconCode,
+      componentName,
+    });
+
+    await createReactIcon({
+      componentName,
+      isSolid,
+      reactIcon,
+      tsx,
+    });
+
+    // I'll make them '*.svg'.
+    await undoRenameIconName({
+      iconName,
+      isSolid,
+    });
+  });
+}
+
+console.log('Building React icons...');
+
+buildReactIcons({
+  isSolid: true,
+});
+
+buildReactIcons({
+  isSolid: false,
+});

--- a/scripts/delete-react-icons.js
+++ b/scripts/delete-react-icons.js
@@ -1,0 +1,4 @@
+const { promisify } = require('util');
+const rimraf = promisify(require('rimraf'));
+rimraf('./react-icons/solid/*');
+rimraf('./react-icons/outline/*');


### PR DESCRIPTION
The `build-react.js` script doesn't work. It has two errors.
1. The buffer doesn't precisely get the raw text when using `fs.readFile(*.svg, 'utf8')`.
2. The paths are all wrong.

I fixed the first problem by changing the extension to `.txt` and re-changing it back to .'svg' after creating the React icons.

I also added a `delete-react-icons` script that makes it possible to delete all the React icons we may create.

I've added some dependencies:
- `"@svgr/plugin-jsx": "^5.5.0",`
- `"@svgr/plugin-prettier": "^5.5.0",`
- `"@svgr/plugin-svgo": "^5.5.0",`
- `"capitalize": "^2.0.3",`
- `"fs-extra": "^9.1.0"`

I've also added a `.prettierrc` to configure the `svgr`'s default format and changed the `README.md` in order to give more information about these new scripts.

Now everything works correctly.

I'll like to add some new features. I'll like to add native Typescript format in `svgr`. But for now, the code just can create `.tsx` or `.js` React components.