### PR TITLE
Svelte Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@
   <a href="https://heroicons.com"><strong>Browse at Heroicons.com &rarr;</strong></a>
 </p>
 
-
 <p align="center">
     <a href="https://github.com/tailwindlabs/heroicons/releases"><img src="https://img.shields.io/npm/v/heroicons" alt="Latest Release"></a>
     <a href="https://github.com/tailwindlabs/heroicons/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/heroicons.svg" alt="License"></a>
 </p>
-
 
 ## Basic Usage
 
@@ -50,7 +48,7 @@ import { BeakerIcon } from '@heroicons/react/solid'
 function MyComponent() {
   return (
     <div>
-      <BeakerIcon className="h-5 w-5 text-blue-500"/>
+      <BeakerIcon className="h-5 w-5 text-blue-500" />
       <p>...</p>
     </div>
   )
@@ -62,7 +60,6 @@ The 24x24 outline icons can be imported from `@heroicons/react/outline`, and the
 Icons use an upper camel case naming convention and are always suffixed with the word `Icon`.
 
 [Browse the full list of icon names on UNPKG &rarr;](https://unpkg.com/browse/@heroicons/react/outline/)
-
 
 ## Vue
 
@@ -77,7 +74,7 @@ Now each icon can be imported individually as a Vue component:
 ```vue
 <template>
   <div>
-    <BeakerIcon class="h-5 w-5 text-blue-500"/>
+    <BeakerIcon class="h-5 w-5 text-blue-500" />
     <p>...</p>
   </div>
 </template>
@@ -86,7 +83,7 @@ Now each icon can be imported individually as a Vue component:
 import { BeakerIcon } from '@heroicons/vue/solid'
 
 export default {
-  components: { BeakerIcon }
+  components: { BeakerIcon },
 }
 </script>
 ```
@@ -96,6 +93,33 @@ The 24x24 outline icons can be imported from `@heroicons/vue/outline`, and the 2
 Icons use an upper camel case naming convention and are always suffixed with the word `Icon`.
 
 [Browse the full list of icon names on UNPKG &rarr;](https://unpkg.com/browse/@heroicons/vue/outline/)
+
+## Svelte
+
+First, install `@heroicons/svelte` from npm:
+
+```sh
+npm install @heroicons/svelte
+```
+
+Now each icon can be imported individually as a Svelte component:
+
+```svelte
+<script>
+import { BeakerIcon } from '@heroicons/svelte/solid'
+</script>
+
+<div>
+  <BeakerIcon class="h-5 w-5 text-blue-500"/>
+  <p>...</p>
+</div>
+```
+
+The 24x24 outline icons can be imported from `@heroicons/svelte/outline`, and the 20x20 solid icons can be imported from `@heroicons/svelte/solid`.
+
+Icons use an upper camel case naming convention and are always suffixed with the word `Icon`.
+
+[Browse the full list of icon names on UNPKG &rarr;](https://unpkg.com/browse/@heroicons/react/outline/)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npm run build-outline && npm run build-solid && npm run build-react && npm run build-vue",
+    "build": "npm run build-outline && npm run build-solid && npm run build-react && npm run build-vue && npm run build-svelte",
     "build-react": "node ./scripts/build.js react",
     "build-vue": "node ./scripts/build.js vue",
     "build-svelte": "node ./scripts/build.js svelte",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@vue/compiler-dom": "^3.0.5",
     "camelcase": "^6.0.0",
     "rimraf": "^3.0.2",
-    "svelte": "^3.37.0",
     "svgo": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "npm run build-outline && npm run build-solid && npm run build-react && npm run build-vue",
     "build-react": "node ./scripts/build.js react",
     "build-vue": "node ./scripts/build.js vue",
+    "build-svelte": "node ./scripts/build.js svelte",
     "build-outline": "rimraf ./outline ./optimized/outline && svgo --config=svgo.outline.yaml -f ./src/outline -o ./optimized/outline --pretty --indent=2 && cp -R ./optimized/outline ./outline",
     "build-solid": "rimraf ./solid ./optimized/solid && svgo --config=svgo.solid.yaml -f ./src/solid -o ./optimized/solid --pretty --indent=2 && cp -R ./optimized/solid ./solid"
   },
@@ -21,6 +22,7 @@
     "@vue/compiler-dom": "^3.0.5",
     "camelcase": "^6.0.0",
     "rimraf": "^3.0.2",
+    "svelte": "^3.37.0",
     "svgo": "^1.3.2"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,7 +5,6 @@ const rimraf = promisify(require('rimraf'))
 const svgr = require('@svgr/core').default
 const babel = require('@babel/core')
 const { compile: compileVue } = require('@vue/compiler-dom')
-const svelte = require('svelte/compiler')
 
 let transform = {
   react: async (svg, componentName, format) => {
@@ -109,6 +108,8 @@ async function buildIcons(package, style, format) {
 
   if (package === 'react') {
     await fs.writeFile(`${outDir}/index.d.ts`, exportAll(icons, 'esm', '.d.ts'), 'utf8')
+  } else if (package === 'svelte') {
+    await fs.writeFile(`${outDir}/index.d.ts`, exportAll(icons, 'esm', '.svelte'), 'utf8')
   }
 }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -118,7 +118,7 @@ function main(package) {
   let pkgJson = `{"module": "./esm/index.js"}`
 
   if (package === 'svelte') {
-    pkgJson = `{"svelte": "./index.js", "module": "./esm/index.js"}`
+    pkgJson = `{"svelte": "./esm/index.js", "module": "./esm/index.js"}`
   }
 
   Promise.all([rimraf(`./${package}/outline/*`), rimraf(`./${package}/solid/*`)])

--- a/svelte/.gitignore
+++ b/svelte/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!package.json

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@heroicons/svelte",
+  "version": "1.0.0",
+  "description": "",
+  "keywords": [],
+  "homepage": "https://github.com/tailwindlabs/heroicons#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tailwindlabs/heroicons.git"
+  },
+  "files": [
+    "outline",
+    "solid"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "svelte": ">= 3"
+  }
+}


### PR DESCRIPTION
Adds Svelte components, which can be built with `npm run build-svelte`. 

They are exported as .svelte components rather than compiled .js files. [This is the recommended way to provide svelte components](https://github.com/sveltejs/component-template#consuming-components) in a library, and are found via the `svelte` entry field in package.json.

If there's a strong argument for compiling them as .js files, I did [do this initially](https://github.com/mattjennings/heroicons/blob/aeafdcfb5ef6f0062f90ca7369a3ef19d968b72c/scripts/build.js#L25) using svelte's [compiler API](https://svelte.dev/docs#svelte_compile) but I could not get them to work in SSR environments. I am sure there's a solution to this, but at that point I felt .svelte components may be best anyway.