### PR TITLE
Add `aria-hidden="true"` attribute

### DIFF
--- a/svgo.outline.yaml
+++ b/svgo.outline.yaml
@@ -7,3 +7,4 @@
   - 'addAttributesToSVGElement':
       attributes:
         - 'stroke': 'currentColor'
+        - 'aria-hidden': 'true'

--- a/svgo.solid.yaml
+++ b/svgo.solid.yaml
@@ -7,3 +7,4 @@
   - 'addAttributesToSVGElement':
       attributes:
         - 'fill': 'currentColor'
+        - 'aria-hidden': 'true'


### PR DESCRIPTION
This PR add `aria-hidden="true"` attribute.

Because icons are almost always a purely decorative element, it would be handy to mark them as `aria-hidden="true"` by default.

They can be re-exposed to `Accessibility Tree` explicitly later in code if needed ( `aria-hidden="false"` ).

Resolves #257 