### PR TITLE
Add missing licenses to npm packages

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heroicons/react",
   "version": "1.0.1",
+  "license": "MIT",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/tailwindlabs/heroicons#readme",

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heroicons/vue",
   "version": "1.0.1",
+  "license": "MIT",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/tailwindlabs/heroicons#readme",


### PR DESCRIPTION
vue and react packages were missing license info on npm