### PR TITLE
Add preview icon in JSDOC (react)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.12",
     "@svgr/core": "^5.5.0",
     "@vue/compiler-dom": "^3.0.5",
+    "base64-img": "^1.0.4",
     "camelcase": "^6.0.0",
     "rimraf": "^3.0.2",
     "svgo": "^1.3.2"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -91,11 +91,11 @@ async function buildIcons(package, style, format) {
 
       if (package === 'react') {
         types = `import * as React from 'react';
-        /**
-         * ${previewImage}
-         */
-        declare function ${componentName}(props: React.ComponentProps<'svg'>): JSX.Element;
-        export default ${componentName};\n`
+/**
+ * ${previewImage}
+ */
+declare function ${componentName}(props: React.ComponentProps<'svg'>): JSX.Element;
+export default ${componentName};\n`
       }
 
       return [

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,6 +508,14 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.5.tgz#c131d88bd6713cc4d93b3bb1372edb1983225ff0"
   integrity sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw==
 
+ajax-request@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/ajax-request/-/ajax-request-1.2.3.tgz#99fcbec1d6d2792f85fa949535332bd14f5f3790"
+  integrity sha1-mfy+wdbSeS+F+pSVNTMr0U9fN5A=
+  dependencies:
+    file-system "^2.1.1"
+    utils-extend "^1.0.7"
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -526,6 +534,14 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-img@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/base64-img/-/base64-img-1.0.4.tgz#3e22d55d6c74a24553d840d2b1bc12a7db078d35"
+  integrity sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=
+  dependencies:
+    ajax-request "^1.2.0"
+    file-system "^2.1.0"
 
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
@@ -766,6 +782,21 @@ estree-walker@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
+file-match@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/file-match/-/file-match-1.0.2.tgz#c9cad265d2c8adf3a81475b0df475859069faef7"
+  integrity sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=
+  dependencies:
+    utils-extend "^1.0.6"
+
+file-system@^2.1.0, file-system@^2.1.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/file-system/-/file-system-2.2.2.tgz#7d65833e3a2347dcd956a813c677153ed3edd987"
+  integrity sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=
+  dependencies:
+    file-match "^1.0.1"
+    utils-extend "^1.0.4"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1152,6 +1183,11 @@ util.promisify@~1.0.0:
     es-abstract "^1.17.2"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
+
+utils-extend@^1.0.4, utils-extend@^1.0.6, utils-extend@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/utils-extend/-/utils-extend-1.0.8.tgz#ccfd7b64540f8e90ee21eec57769d0651cab8a5f"
+  integrity sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8=
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Hi,
Very nice icons library, just a little addition to improve the DX

![47bf7f7b-eb4e-40ca-9a88-6ae39c5d0387](https://user-images.githubusercontent.com/1761469/119981739-41966980-bfbe-11eb-9c2d-68adbf6b8a56.gif)

The trick is to add the svg as a base64 image inside a markdown image markup into the JSDoc. Doing this improve the searchability of every icons, since we can just see the icon in intellisense 😀

