### PR TITLE
chore: add MIT licence to package(s).json

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heroicons/react",
   "version": "1.0.3",
+  "license": "MIT",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/tailwindlabs/heroicons#readme",

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heroicons/vue",
   "version": "1.0.3",
+  "license": "MIT",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/tailwindlabs/heroicons#readme",


### PR DESCRIPTION
Missing license field in react and vue package.json.

I just added the MIT as found in project root.

That helps to identify the licence in npm, ie: https://www.npmjs.com/package/@heroicons/react and will silent licence checkers (fossa..)