### PR TITLE
Added README.md to package.json's Files Array

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "files": [
     "outline/",
-    "solid/"
+    "solid/",
+    "README.md"
   ],
   "scripts": {
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
Added a README.md to package.json's Files Array so npm displays it at https://www.npmjs.com/package/@heroicons/react.

Currently looks this empty
![image](https://user-images.githubusercontent.com/51504825/128473700-c022cb75-bc07-46b4-9ee7-30673b46341d.png)
