### PR TITLE
Fix solid arrows-expand fill color

### DIFF
--- a/optimized/solid/arrows-expand.svg
+++ b/optimized/solid/arrows-expand.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 20" fill="currentColor">
-  <path stroke="#374151" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8V4m0 0h4M3 4l4 4m8 0V4m0 0h-4m4 0l-4 4m-8 4v4m0 0h4m-4 0l4-4m8 4l-4-4m4 4v-4m0 4h-4"/>
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8V4m0 0h4M3 4l4 4m8 0V4m0 0h-4m4 0l-4 4m-8 4v4m0 0h4m-4 0l4-4m8 4l-4-4m4 4v-4m0 4h-4"/>
 </svg>


### PR DESCRIPTION
This fixes the hard-coded fill color for the Solid "arrows-expand" icon.