### PR TITLE
Fix vue TypeScript declarations, again

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -86,7 +86,7 @@ async function buildIcons(package, style, format) {
       let types =
         package === 'react'
           ? `import * as React from 'react';\ndeclare function ${componentName}(props: React.ComponentProps<'svg'>): JSX.Element;\nexport default ${componentName};\n`
-          : `import { RenderFunction } from 'vue';\ndeclare const ${componentName}: RenderFunction;\nexport default ${componentName};\n`
+          : `import { DefineComponent } from 'vue';\ndeclare const ${componentName}: DefineComponent;\nexport default ${componentName};\n`
 
       return [
         fs.writeFile(`${outDir}/${componentName}.js`, content, 'utf8'),


### PR DESCRIPTION
I'm not sure why `DefineComponent` was changed to `RenderFunction` in #322, but it has a wrong signature (returns `VNodeChild` instead of `VNode`) and is now causing #516 with newer versions of `vue-tsc` (allegedly, I didn't downgrade it to check):

  error TS2786: '...' cannot be used as a JSX component.
    Its return type 'VNodeChild' is not a valid JSX element.
      Type 'undefined' is not assignable to type 'Element | null'.

as documented in #516. So here we change `RenderFunction` back to `DefineComponent`.