### PR TITLE
Add sideEffects to package json files

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,6 +5,7 @@ const rimraf = promisify(require('rimraf'))
 const svgr = require('@svgr/core').default
 const babel = require('@babel/core')
 const { compile: compileVue } = require('@vue/compiler-dom')
+const { dirname } = require('path')
 
 let transform = {
   react: async (svg, componentName, format) => {
@@ -70,13 +71,20 @@ function exportAll(icons, format, includeExtension = true) {
     .join('\n')
 }
 
+async function ensureWrite(file, text) {
+  await fs.mkdir(dirname(file), { recursive: true })
+  await fs.writeFile(file, text, 'utf8')
+}
+
+async function ensureWriteJson(file, json) {
+  await ensureWrite(file, JSON.stringify(json, null, 2))
+}
+
 async function buildIcons(package, style, format) {
   let outDir = `./${package}/${style}`
   if (format === 'esm') {
     outDir += '/esm'
   }
-
-  await fs.mkdir(outDir, { recursive: true })
 
   let icons = await getIcons(style)
 
@@ -89,40 +97,43 @@ async function buildIcons(package, style, format) {
           : `import { RenderFunction } from 'vue';\ndeclare const ${componentName}: RenderFunction;\nexport default ${componentName};\n`
 
       return [
-        fs.writeFile(`${outDir}/${componentName}.js`, content, 'utf8'),
-        ...(types ? [fs.writeFile(`${outDir}/${componentName}.d.ts`, types, 'utf8')] : []),
+        ensureWrite(`${outDir}/${componentName}.js`, content),
+        ...(types ? [ensureWrite(`${outDir}/${componentName}.d.ts`, types)] : []),
       ]
     })
   )
 
-  await fs.writeFile(`${outDir}/index.js`, exportAll(icons, format), 'utf8')
+  await ensureWrite(`${outDir}/index.js`, exportAll(icons, format))
 
-  await fs.writeFile(`${outDir}/index.d.ts`, exportAll(icons, 'esm', false), 'utf8')
+  await ensureWrite(`${outDir}/index.d.ts`, exportAll(icons, 'esm', false))
 }
 
-function main(package) {
+async function main(package) {
+  const cjsPackageJson = { module: './esm.index.js', sideEffects: false }
+  const esmPackageJson = { type: 'module', sideEffects: false }
+
   console.log(`Building ${package} package...`)
 
-  Promise.all([rimraf(`./${package}/outline/*`), rimraf(`./${package}/solid/*`)])
-    .then(() =>
-      Promise.all([
-        buildIcons(package, 'solid', 'esm'),
-        buildIcons(package, 'solid', 'cjs'),
-        buildIcons(package, 'outline', 'esm'),
-        buildIcons(package, 'outline', 'cjs'),
-        fs.writeFile(`./${package}/outline/package.json`, `{"module": "./esm/index.js"}`, 'utf8'),
-        fs.writeFile(`./${package}/outline/esm/package.json`, `{"type": "module"}`, 'utf8'),
-        fs.writeFile(`./${package}/solid/package.json`, `{"module": "./esm/index.js"}`, 'utf8'),
-        fs.writeFile(`./${package}/solid/esm/package.json`, `{"type": "module"}`, 'utf8'),
-      ])
-    )
-    .then(() => console.log(`Finished building ${package} package.`))
+  await Promise.all([rimraf(`./${package}/outline/*`), rimraf(`./${package}/solid/*`)])
+
+  await Promise.all([
+    buildIcons(package, 'solid', 'esm'),
+    buildIcons(package, 'solid', 'cjs'),
+    buildIcons(package, 'outline', 'esm'),
+    buildIcons(package, 'outline', 'cjs'),
+    ensureWriteJson(`./${package}/outline/package.json`, cjsPackageJson),
+    ensureWriteJson(`./${package}/outline/esm/package.json`, esmPackageJson),
+    ensureWriteJson(`./${package}/solid/package.json`, cjsPackageJson),
+    ensureWriteJson(`./${package}/solid/esm/package.json`, esmPackageJson),
+  ])
+
+  return console.log(`Finished building ${package} package.`)
 }
 
 let [package] = process.argv.slice(2)
 
 if (!package) {
-  throw Error('Please specify a package')
+  throw new Error('Please specify a package')
 }
 
 main(package)


### PR DESCRIPTION
Adds sideEffects to package.json files, plus some misc. cleanup and improvements

Rationale: bundlers like webpack and esbuild use this field to drop unused symbols. See https://esbuild.github.io/api/#tree-shaking