### PR TITLE
Implement Hex.pm package for Heroicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ Icons use an upper camel case naming convention and are always suffixed with the
 
 [Browse the full list of icon names on UNPKG &rarr;](https://unpkg.com/browse/@heroicons/vue/outline/)
 
+## Elixir/Phoenix
+
+First, add `phoenix_heroicons` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [{:phoenix_heroicons, "~> 0.1.0"}]
+end
+```
+
+Now, any icon can be referenced in a template via the `PhoenixHeroicons` module's `svg` funcion:
+
+```elixir
+<%= PhoenixHeroicons.svg("solid/thumb-up", class: "h-6 w-6 text-green-400") %>
+```
+
+Any attributes passed to the optional second argument will be placed on the outer `svg` element as part of rendering.
+
 ## License
 
 This library is MIT licensed.

--- a/elixir/.formatter.exs
+++ b/elixir/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/elixir/.gitignore
+++ b/elixir/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+heroicons-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/elixir/lib/phoenix_heroicons.ex
+++ b/elixir/lib/phoenix_heroicons.ex
@@ -1,0 +1,46 @@
+defmodule PhoenixHeroicons do
+  @moduledoc """
+  Elixir module for rendering HTML-safe HeroIcon SVGs
+  """
+  icon_tuples =
+    "./optimized/**/*.svg"
+    |> Path.wildcard()
+    |> Enum.sort()
+    |> Enum.map(&Path.relative_to_cwd/1)
+    |> Enum.map(fn path ->
+      contents =
+        path
+        |> File.read!()
+        |> Floki.parse_fragment!()
+
+      [category, name] =
+        path
+        |> Path.split()
+        |> Enum.drop(1)
+
+      name = String.replace_suffix(name, ".svg", "")
+
+      {"#{category}/#{name}", contents}
+    end)
+
+  @icons Enum.into(icon_tuples, %{})
+
+  @doc """
+    Gets an HTML-safe SVG for use in a Phoenix template for the given Heroicon. The specified
+    attributes will overwrite attributes on the root `svg` element.
+  """
+  def svg(name, attrs \\ []) do
+    case Map.get(@icons, name) do
+      nil ->
+        nil
+
+      icon ->
+        Enum.reduce(attrs, icon, fn {key, val}, icon ->
+          key = if is_atom(key), do: Atom.to_string(key), else: key
+          Floki.attr(icon, "svg", key, fn _ -> val end)
+        end)
+        |> Floki.raw_html()
+        |> Phoenix.HTML.raw()
+    end
+  end
+end

--- a/elixir/mix.lock
+++ b/elixir/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "floki": {:hex, :floki, "0.33.1", "f20f1eb471e726342b45ccb68edb9486729e7df94da403936ea94a794f072781", [:mix], [{:html_entities, "~> 0.5.0", [hex: :html_entities, repo: "hexpm", optional: false]}], "hexpm", "461035fd125f13fdf30f243c85a0b1e50afbec876cbf1ceefe6fddd2e6d712c6"},
+  "html_entities": {:hex, :html_entities, "0.5.2", "9e47e70598da7de2a9ff6af8758399251db6dbb7eebe2b013f2bbd2515895c3c", [:mix], [], "hexpm", "c53ba390403485615623b9531e97696f076ed415e8d8058b1dbaa28181f4fdcc"},
+  "phoenix_html": {:hex, :phoenix_html, "3.2.0", "1c1219d4b6cb22ac72f12f73dc5fad6c7563104d083f711c3fcd8551a1f4ae11", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm", "36ec97ba56d25c0136ef1992c37957e4246b649d620958a1f9fa86165f8bc54f"},
+}

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,40 @@
+defmodule PhoenixHeroicons.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :phoenix_heroicons,
+      version: "0.1.0",
+      elixir: "~> 1.7",
+      deps: deps(),
+      name: "PhoenixHeroicons",
+      description: "Mix package to incorporate Heroicons SVGs into an Elixir Phoenix project",
+      package: package(),
+      elixirc_paths: ["elixir/lib"],
+      lockfile: Path.expand("elixir/mix.lock", __DIR__),
+      deps_path: Path.expand("elixir/deps", __DIR__),
+      build_path: Path.expand("elixir/_build", __DIR__)
+    ]
+  end
+
+  def application, do: []
+
+  defp deps do
+    [
+      {:phoenix_html, ">= 3.0.0"},
+      {:floki, ">= 0.25.0"}
+    ]
+  end
+
+  defp package do
+    [
+      files: ["elixir/lib", "optimized"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/tailwindlabs/heroicons"},
+      maintainers: [
+        "Adam Wathan",
+        "Andrew Morin"
+      ]
+    ]
+  end
+end


### PR DESCRIPTION
This pull request implements an Elixir module for serving up phoenix HTML-safe content for each heroicon SVG. This package could be built and pushed to `hex.pm` and then installed in any elixir project for rendering heroicon SVGs. Builder/maintainer of the package is TBD if this PR is approved.

To test, add the following dependency to an Elixir project:
```
{:phoenix_heroicons, git: "https://github.com/morinap/heroicons", branch: "elixir-icons"},
```

Then, within any template, render an icon like this:
```
<%= PhoenixHeroicons.svg("solid/thumb-up", class: "h-6 w-6 text-green-400") %>
```