### PR TITLE
Allow setting title via prop

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,7 +9,7 @@ const { dirname } = require('path')
 
 let transform = {
   react: async (svg, componentName, format) => {
-    let component = await svgr(svg, { ref: true }, { componentName })
+    let component = await svgr(svg, { ref: true, titleProp: true }, { componentName })
     let { code } = await babel.transformAsync(component, {
       plugins: [[require('@babel/plugin-transform-react-jsx'), { useBuiltIns: true }]],
     })


### PR DESCRIPTION
This enables `svgr`'s [`titleProp`](https://react-svgr.com/docs/options/#title) option which allows adding a `<title>` to jsx icons via prop.