### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,55 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: git fetch --tags -f
+
+      - name: Resolve version
+        id: vars
+        run: |
+          echo "TAG_NAME=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+      - name: Get release notes
+        run: |
+          RELEASE_NOTES=$(npm run release-notes --silent)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}
+          body: |
+            ${{ env.RELEASE_NOTES }}

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CI: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,17 +19,17 @@ jobs:
         node-version: [18]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Use cached node_modules
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}
@@ -36,36 +39,31 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
-        env:
-          CI: true
 
-      - name: Resolve version
-        id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Calculate environment variables
+        run: |
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: "Version `heroicons` based on commit: 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}"
-        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force --no-git-tag-version
+      - name: "Version `heroicons` based on commit: 0.0.0-insiders.${{ env.SHA_SHORT }}"
+        run: npm version 0.0.0-insiders.${{ env.SHA_SHORT }} --force --no-git-tag-version
 
-      - name: "Version `@heroicons/react` based on commit: 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}"
-        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force --no-git-tag-version --prefix react
+      - name: "Version `@heroicons/react` based on commit: 0.0.0-insiders.${{ env.SHA_SHORT }}"
+        run: npm version 0.0.0-insiders.${{ env.SHA_SHORT }} --force --no-git-tag-version --prefix react
 
-      - name: "Version `@heroicons/vue` based on commit: 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}"
-        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force --no-git-tag-version --prefix vue
+      - name: "Version `@heroicons/vue` based on commit: 0.0.0-insiders.${{ env.SHA_SHORT }}"
+        run: npm version 0.0.0-insiders.${{ env.SHA_SHORT }} --force --no-git-tag-version --prefix vue
 
       - name: Publish `heroicons`
         run: npm publish --tag insiders
         env:
-          CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish `@heroicons/react`
         run: npm publish ./react --tag insiders
         env:
-          CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish `@heroicons/vue`
         run: npm publish ./vue --tag insiders
         env:
-          CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use cached node_modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}
+          restore-keys: |
+            nodeModules-
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
+
+      - name: Calculate environment variables
+        run: |
+          echo "RELEASE_CHANNEL=$(npm run release-channel --silent)" >> $GITHUB_ENV
+
+      - name: Publish `heroicons`
+        run: npm publish --tag ${{ env.RELEASE_CHANNEL }}  
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish `@heroicons/react`
+        run: npm publish ./react --tag ${{ env.RELEASE_CHANNEL }}  
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish `@heroicons/vue`
+        run: npm publish ./vue --tag ${{ env.RELEASE_CHANNEL }}  
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `minus` icon alignment ([0a88242](https://github.com/tailwindlabs/heroicons/commit/0a88242ffddbd79177b8cd4cf954d3a54be121a6))
+
+## [2.0.12] - 2022-10-05
+
+### Fixed
+
 - Add `title` and `titleId` props to the React types ([#814](https://github.com/tailwindlabs/heroicons/pull/814))
 - Fix `information-circle` icon alignment ([#846](https://github.com/tailwindlabs/heroicons/pull/846))
-- Fix `minus` icon alignment ([0a88242](https://github.com/tailwindlabs/heroicons/commit/0a88242ffddbd79177b8cd4cf954d3a54be121a6))
 
 ## [2.0.11] - 2022-09-12
 
@@ -181,7 +186,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Everything!
 
-[unreleased]: https://github.com/tailwindlabs/heroicons/compare/v2.0.11...HEAD
+[unreleased]: https://github.com/tailwindlabs/heroicons/compare/v2.0.12...HEAD
+[2.0.12]: https://github.com/tailwindlabs/heroicons/compare/v2.0.11...v2.0.12
 [2.0.11]: https://github.com/tailwindlabs/heroicons/compare/v2.0.10...v2.0.11
 [2.0.10]: https://github.com/tailwindlabs/heroicons/compare/v2.0.9...v2.0.10
 [2.0.9]: https://github.com/tailwindlabs/heroicons/compare/v2.0.8...v2.0.9

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build-vue": "node ./scripts/build.js vue",
     "build-24-outline": "rimraf ./24/outline ./optimized/24/outline && svgo --config=svgo.24.outline.yaml -f ./src/24/outline -o ./optimized/24/outline --pretty --indent=2 && mkdir -p ./24 && cp -R ./optimized/24/outline ./24/outline",
     "build-20-solid": "rimraf ./20/solid ./optimized/20/solid && svgo --config=svgo.20.solid.yaml -f ./src/20/solid -o ./optimized/20/solid --pretty --indent=2 && mkdir -p ./20 && cp -R ./optimized/20/solid ./20/solid",
-    "build-24-solid": "rimraf ./24/solid ./optimized/24/solid && svgo --config=svgo.24.solid.yaml -f ./src/24/solid -o ./optimized/24/solid --pretty --indent=2 && mkdir -p ./24 && cp -R ./optimized/24/solid ./24/solid"
+    "build-24-solid": "rimraf ./24/solid ./optimized/24/solid && svgo --config=svgo.24.solid.yaml -f ./src/24/solid -o ./optimized/24/solid --pretty --indent=2 && mkdir -p ./24 && cp -R ./optimized/24/solid ./24/solid",
+    "release-channel": "node ./scripts/release-channel.js",
+    "release-notes": "node ./scripts/release-notes.js"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/scripts/release-channel.js
+++ b/scripts/release-channel.js
@@ -1,0 +1,18 @@
+// Given a version, figure out what the release channel is so that we can publish to the correct
+// channel on npm.
+//
+// E.g.:
+//
+//   1.2.3                  -> latest (default)
+//   0.0.0-insiders.ffaa88  -> insiders
+//   4.1.0-alpha.4          -> alpha
+
+let version =
+  process.argv[2] || process.env.npm_package_version || require('../package.json').version
+
+let match = /\d+\.\d+\.\d+-(.*)\.\d+/g.exec(version)
+if (match) {
+  console.log(match[1])
+} else {
+  console.log('latest')
+}

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,21 @@
+// Given a version, figure out what the release notes are so that we can use this to pre-fill the
+// relase notes on a GitHub release for the current version.
+
+let path = require('path')
+let fs = require('fs')
+
+let version =
+  process.argv[2] || process.env.npm_package_version || require('../package.json').version
+
+let changelog = fs.readFileSync(path.resolve(__dirname, '..', 'CHANGELOG.md'), 'utf8')
+let match = new RegExp(
+  `## \\[${version}\\] - (.*)\\n\\n([\\s\\S]*?)\\n(?:(?:##\\s)|(?:\\[))`,
+  'g'
+).exec(changelog)
+
+if (match) {
+  let [, , notes] = match
+  console.log(notes.trim())
+} else {
+  console.log(`Placeholder release notes for version: v${version}`)
+}


### PR DESCRIPTION
This PR adds similar release workflows as we have for Tailwind CSS.

When a tag is pushed, a draft release is created with the CHANGELOG.md notes. When a release on
GitHub is published, then a new workflow will be triggered and will release Heroicons on npm (with
React & Vue versions as well).
