### PR TITLE
Fix React ref type

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -93,7 +93,7 @@ async function buildIcons(package, style, format) {
       let content = await transform[package](svg, componentName, format)
       let types =
         package === 'react'
-          ? `import * as React from 'react';\ndeclare function ${componentName}(props: React.ComponentProps<'svg'> & { title?: string, titleId?: string }): JSX.Element;\nexport default ${componentName};\n`
+          ? `import * as React from 'react';\ndeclare const ${componentName}: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & { title?: string, titleId?: string }>;\nexport default ${componentName};\n`
           : `import type { FunctionalComponent, HTMLAttributes, VNodeProps } from 'vue';\ndeclare const ${componentName}: FunctionalComponent<HTMLAttributes & VNodeProps>;\nexport default ${componentName};\n`
 
       return [


### PR DESCRIPTION
Fix ref types for React

E.g. this should be valid

```tsx
function App() {
  const ref = useRef<SVGSVGElement | null>(null)
  return <Icon ref={ref} />
}
```

Also changes `React.ComponentProps<'svg'>` to `React.SVGProps<SVGSVGElement>`  which is what React internally uses for `<svg>` elements