### PR TITLE
Mark Vue and React packages as side-effect free

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -15,6 +15,7 @@
     "solid",
     "outline"
   ],
+  "sideEffects": false,
   "exports": {
     "./package.json": {
       "default": "./package.json"

--- a/vue/package.json
+++ b/vue/package.json
@@ -15,6 +15,7 @@
     "outline",
     "solid"
   ],
+  "sideEffects": false,
   "exports": {
     "./package.json": {
       "default": "./package.json"


### PR DESCRIPTION
Apparently adding an `exports` field implicitly marks a package as having side-effects _in some cases_ even when direct imports of a file didn't previously do so.

Rollup and esbuild seem to not care about this when dealing with files directly. But Vite's internal node resolution logic does. I'm guessing Remix might be in a similar situation here. We export pure render functions for both React and Vue so marking our packages with `"sideEffects": false` should be fine.

Fixes #926