### PR TITLE
Add root-level import

### DIFF
--- a/react/.gitignore
+++ b/react/.gitignore
@@ -1,4 +1,5 @@
 *
+!*.js
 !.gitignore
 !package.json
 !outline

--- a/react/index.esm.js
+++ b/react/index.esm.js
@@ -1,3 +1,5 @@
+// The only reason this file exists is to appease Vite's optimizeDeps feature which requires a root-level import.
+
 export default new Proxy(
   {},
   {

--- a/react/index.esm.js
+++ b/react/index.esm.js
@@ -7,7 +7,7 @@ export default new Proxy(
       }
 
       throw new Error(
-        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+        `Importing from \`@heroicons/react\` directly is not supported. Please import from either \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
       )
     },
   }

--- a/react/index.esm.js
+++ b/react/index.esm.js
@@ -1,0 +1,14 @@
+export default new Proxy(
+  {},
+  {
+    get: (_, property) => {
+      if (property === '__esModule') {
+        return {}
+      }
+
+      throw new Error(
+        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+      )
+    },
+  }
+)

--- a/react/index.js
+++ b/react/index.js
@@ -7,7 +7,7 @@ module.exports = new Proxy(
       }
 
       throw new Error(
-        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+        `Importing from \`@heroicons/react\` directly is not supported. Please import from either \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
       )
     },
   }

--- a/react/index.js
+++ b/react/index.js
@@ -1,0 +1,14 @@
+module.exports = new Proxy(
+  {},
+  {
+    get: (_, property) => {
+      if (property === '__esModule') {
+        return {}
+      }
+
+      throw new Error(
+        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+      )
+    },
+  }
+)

--- a/react/index.js
+++ b/react/index.js
@@ -1,3 +1,5 @@
+// The only reason this file exists is to appease Vite's optimizeDeps feature which requires a root-level import.
+
 module.exports = new Proxy(
   {},
   {

--- a/react/package.json
+++ b/react/package.json
@@ -17,6 +17,10 @@
   ],
   "sideEffects": false,
   "exports": {
+    ".": {
+      "import": "./index.esm.js",
+      "require": "./index.js"
+    },
     "./package.json": {
       "default": "./package.json"
     },

--- a/vue/.gitignore
+++ b/vue/.gitignore
@@ -1,3 +1,4 @@
 *
+!*.js
 !.gitignore
 !package.json

--- a/vue/index.esm.js
+++ b/vue/index.esm.js
@@ -7,7 +7,7 @@ export default new Proxy(
       }
 
       throw new Error(
-        `You\'re trying to import from \`@heroicons/vue\` directly which will not work. Please import from one of \`@heroicons/vue/20/solid\`, \`@heroicons/vue/24/solid\`, or \`@heroicons/vue/24/outline\` instead.`
+        `Importing from \`@heroicons/vue\` directly is not supported. Please import from either \`@heroicons/vue/20/solid\`, \`@heroicons/vue/24/solid\`, or \`@heroicons/vue/24/outline\` instead.`
       )
     },
   }

--- a/vue/index.esm.js
+++ b/vue/index.esm.js
@@ -1,3 +1,5 @@
+// The only reason this file exists is to appease Vite's optimizeDeps feature which requires a root-level import.
+
 export default new Proxy(
   {},
   {

--- a/vue/index.esm.js
+++ b/vue/index.esm.js
@@ -1,0 +1,14 @@
+export default new Proxy(
+  {},
+  {
+    get: (_, property) => {
+      if (property === '__esModule') {
+        return {}
+      }
+
+      throw new Error(
+        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+      )
+    },
+  }
+)

--- a/vue/index.esm.js
+++ b/vue/index.esm.js
@@ -7,7 +7,7 @@ export default new Proxy(
       }
 
       throw new Error(
-        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+        `You\'re trying to import from \`@heroicons/vue\` directly which will not work. Please import from one of \`@heroicons/vue/20/solid\`, \`@heroicons/vue/24/solid\`, or \`@heroicons/vue/24/outline\` instead.`
       )
     },
   }

--- a/vue/index.js
+++ b/vue/index.js
@@ -7,7 +7,7 @@ module.exports = new Proxy(
       }
 
       throw new Error(
-        `You\'re trying to import from \`@heroicons/vue\` directly which will not work. Please import from one of \`@heroicons/vue/20/solid\`, \`@heroicons/vue/24/solid\`, or \`@heroicons/vue/24/outline\` instead.`
+        `Importing from \`@heroicons/vue\` directly is not supported. Please import from either \`@heroicons/vue/20/solid\`, \`@heroicons/vue/24/solid\`, or \`@heroicons/vue/24/outline\` instead.`
       )
     },
   }

--- a/vue/index.js
+++ b/vue/index.js
@@ -7,7 +7,7 @@ module.exports = new Proxy(
       }
 
       throw new Error(
-        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+        `You\'re trying to import from \`@heroicons/vue\` directly which will not work. Please import from one of \`@heroicons/vue/20/solid\`, \`@heroicons/vue/24/solid\`, or \`@heroicons/vue/24/outline\` instead.`
       )
     },
   }

--- a/vue/index.js
+++ b/vue/index.js
@@ -1,0 +1,14 @@
+module.exports = new Proxy(
+  {},
+  {
+    get: (_, property) => {
+      if (property === '__esModule') {
+        return {}
+      }
+
+      throw new Error(
+        `You\'re trying to import from \`@heroicons/react\` directly which will not work. Please import from one of \`@heroicons/react/20/solid\`, \`@heroicons/react/24/solid\`, or \`@heroicons/react/24/outline\` instead.`
+      )
+    },
+  }
+)

--- a/vue/index.js
+++ b/vue/index.js
@@ -1,3 +1,5 @@
+// The only reason this file exists is to appease Vite's optimizeDeps feature which requires a root-level import.
+
 module.exports = new Proxy(
   {},
   {

--- a/vue/package.json
+++ b/vue/package.json
@@ -17,6 +17,10 @@
   ],
   "sideEffects": false,
   "exports": {
+    ".": {
+      "import": "./index.esm.js",
+      "require": "./index.js"
+    },
     "./package.json": {
       "default": "./package.json"
     },


### PR DESCRIPTION
Vite has an `optimizeDeps` pass that does not like that you can't import from `@heroicons/react` or `@heroicons/vue` directly. This is because we do not have a `main` / `module` / `exports."."` entry in our package.json. This was intentional because such an import is invalid. You must import from one of:
- `@heroicons/react/20/solid`
- `@heroicons/react/24/solid`
- `@heroicons/react/24/outline`
- `@heroicons/vue/20/solid`
- `@heroicons/vue/24/solid`
- `@heroicons/vue/24/outline`

However, because of this problem we need one to exist for Vite to not break if it decides to optimize deps and include `@heroicons/react` (or `@heroicons/vue`) either because there's many packages, because the user has forced them on for all packages, or it's been explicitly included by the user.

This PR solves this by adding root-level entry points for `@heroicons/react` and `@heroicons/vue`. If someone tries to use these imports directly we will throw an error at runtime letting them know the correct path(s) to import.

Fixes #934