### PR TITLE
Use `size-*` instead of `w-* h-*`

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -35,7 +35,7 @@ import { BeakerIcon } from '@heroicons/react/24/solid'
 function MyComponent() {
   return (
     <div>
-      <BeakerIcon className="h-6 w-6 text-blue-500" />
+      <BeakerIcon className="size-6 text-blue-500" />
       <p>...</p>
     </div>
   )

--- a/vue/README.md
+++ b/vue/README.md
@@ -32,7 +32,7 @@ Now each icon can be imported individually as a Vue component:
 ```vue
 <template>
   <div>
-    <BeakerIcon class="h-6 w-6 text-blue-500" />
+    <BeakerIcon class="size-6 text-blue-500" />
     <p>...</p>
   </div>
 </template>


### PR DESCRIPTION
This PR uses `size-*` instead of `w-*` and `h-*` classes in the readme for React and Vue.

