### PR TITLE
Make sure calls to `forwardRef` are marked as pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Improve tree-shakability of React package ([#1192](https://github.com/tailwindlabs/heroicons/pull/1192))
 
 ## [2.1.3] - 2024-03-22
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -23,6 +23,8 @@ let transform = {
       code = lines.join('\n')
     }
 
+    code = code.replace('React.forwardRef(', '/*#__PURE__*/ React.forwardRef(')
+
     if (format === 'esm') {
       return code
     }


### PR DESCRIPTION
`React.forwardRef` should always be marked as pure and doing so can help with tree shaking in some build tools. 

Fixes #1171