### PR TITLE
feat: Add chevron down up svg

### DIFF
--- a/src/24/outline/chevron-down-up.svg
+++ b/src/24/outline/chevron-down-up.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.25 18.75 L12 15 L15.75 18.75 M8.25 5.25 L12 9 L15.75  5.25" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Added `ChevronDownUpIcon` to complement `ChevronUpDownIcon`.

There's an existing suggestion here:
https://github.com/tailwindlabs/heroicons/discussions/942#discussion-4894327