### PR TITLE
Add React 19 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add React 19 support ([#1247](https://github.com/tailwindlabs/heroicons/pull/1247))
+
 ### Fixed
 
-- Removed unncessary clipping path from `solid/arrow-left-circle` ([#1211](https://github.com/tailwindlabs/heroicons/pull/1211))
+- Removed unnecessary clipping path from `solid/arrow-left-circle` ([#1211](https://github.com/tailwindlabs/heroicons/pull/1211))
 
 ## [2.1.5] - 2024-07-10
 

--- a/react/package.json
+++ b/react/package.json
@@ -144,6 +144,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": ">= 16"
+    "react": ">= 16 || ^19.0.0-rc"
   }
 }


### PR DESCRIPTION
Resolves #1240
Resolves https://github.com/tailwindlabs/tailwindui-issues/issues/1647

This PR adds the React 19 RC support to the Heroicons React package. Technically everything already worked in React 19, we just needed to update the dependencies.