### PR TITLE
Fix main package metadata via `npm pkg fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "svg",
     "tailwindcss"
   ],
-  "repository": "https://github.com/tailwindlabs/heroicons.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/heroicons.git"
+  },
   "files": [
     "16/",
     "20/",


### PR DESCRIPTION
Fix a warning when running `npm publish --dry-run`

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+https://github.com/tailwindlabs/heroicons.git"
```

---

Hello,

I don't know if this can have side effects with `provenance`